### PR TITLE
Fixed API to work with HTTPS.

### DIFF
--- a/strawpoll/api.py
+++ b/strawpoll/api.py
@@ -18,7 +18,7 @@ class API:
     `None`, which will grab the default event loop instead.
     """
 
-    _BASE_URL = 'http://www.strawpoll.me'
+    _BASE_URL = 'https://www.strawpoll.me'
     _BASE_API = _BASE_URL + '/api/v2'
     _POLLS = _BASE_API + '/polls'
 


### PR DESCRIPTION
As of around February 20, strawpoll has updated their API and now only accepts POST requests made through `https`. 

This update allows API wrapper to make POST requests again by simply changing to use `https` rather than `http`.